### PR TITLE
Several improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Docker override file (may want to add custom printer path)
+docker-compose.override.yml
+
 # ignore config.json
 config.json
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,19 @@
 FROM python:3-alpine
 
-COPY . /app
 WORKDIR /app
+
+# First, copy only the requirements.txt
+# This ensures the dependencies can be sourced from docker's cache (and save a
+# lot of time during building) *unless* the requirements.txt file actually
+# changes
+COPY ./requirements.txt /app/requirements.txt
 
 RUN apk add fontconfig \
     git \
     ttf-dejavu \
     ttf-liberation \
     ttf-droid \
+    ttf-freefont \
     font-terminus \
     font-inconsolata \
     font-dejavu \
@@ -15,6 +21,8 @@ RUN apk add fontconfig \
     poppler-utils && \
     fc-cache -f && \
     pip3 install -r requirements.txt
+
+COPY . /app
 
 EXPOSE 8013
 ENTRYPOINT [ "python3", "run.py" ]

--- a/README.md
+++ b/README.md
@@ -32,6 +32,27 @@ For now I have added Docker support and the ability to print red images on suppo
 -   Print images on red/black paper
 -   Dockerized
 
+### Docker Compose
+
+You may also use the example [`docker-compose.yml`](./docker-compose.yml) file provided in this repository to quickly get started with Docker Compose:
+
+``` yaml
+services:
+  brother_ql_web:
+    image: davidramiro/brother-ql-web:latest # latest online version
+    # build: . # building locally from source (see git clone below)
+    container_name: brother_ql_web
+    restart: always
+    ports:
+      - "8013:8013"
+    devices:
+      - "/dev/usb/lp0:/dev/usb/lp0"
+    command: >
+      --model QL-800
+      --default-label-size 62
+      file:///dev/usb/lp0
+```
+
 ### Run via Docker
 
 You can pull the image from `davidramiro/brother-ql-web` on Docker Hub.

--- a/app/labeldesigner/label.py
+++ b/app/labeldesigner/label.py
@@ -140,7 +140,7 @@ class SimpleLabel:
     def label_type(self, value):
         self._label_type = value
 
-    def generate(self):
+    def generate(self, rotate = False):
         if self._label_content in (LabelContent.QRCODE_ONLY, LabelContent.TEXT_QRCODE):
             img = self._generate_qr()
         elif self._label_content in (LabelContent.IMAGE_BW, LabelContent.IMAGE_GRAYSCALE, LabelContent.IMAGE_RED_BLACK, LabelContent.IMAGE_COLORED):
@@ -254,6 +254,15 @@ class SimpleLabel:
                 font=self._get_font(),
                 align=self._text_align,
                 spacing=int(self._font_size*((self._line_spacing - 100) / 100)))
+
+        # Check if the image needs rotation (only applied when generating
+        # preview images)
+        preview_needs_rotation = (
+            self._label_orientation == LabelOrientation.ROTATED and self._label_type not in (LabelType.DIE_CUT_LABEL, LabelType.ROUND_DIE_CUT_LABEL) or \
+            self._label_orientation == LabelOrientation.STANDARD and self._label_type in (LabelType.DIE_CUT_LABEL, LabelType.ROUND_DIE_CUT_LABEL)
+        )
+        if rotate and preview_needs_rotation:
+            imgResult = imgResult.rotate(-90, expand=True)
 
         return imgResult
 

--- a/app/labeldesigner/label.py
+++ b/app/labeldesigner/label.py
@@ -1,7 +1,9 @@
 from enum import Enum, auto
 from qrcode import QRCode, constants
 from PIL import Image, ImageDraw, ImageFont
+import logging
 
+logger = logging.getLogger(__name__)
 
 class LabelContent(Enum):
     TEXT_ONLY = auto()
@@ -31,6 +33,28 @@ class TextAlign(Enum):
 
 
 class SimpleLabel:
+    def _ensure_pil_image(self, img) -> Image.Image:
+        """Ensure the image is a PIL.Image.Image instance."""
+        if isinstance(img, Image.Image):
+            return img
+        # Try to convert PyPNGImage or other types to PIL.Image
+        try:
+            # Try to get bytes and open as PIL
+            import io
+            if hasattr(img, 'tobytes') and hasattr(img, 'size') and hasattr(img, 'mode'):
+                return Image.frombytes(img.mode, img.size, img.tobytes())
+            elif hasattr(img, 'to_pil_image'):
+                return img.to_pil_image()
+            elif hasattr(img, 'as_pil_image'):
+                return img.as_pil_image()
+            elif hasattr(img, 'save'):
+                buf = io.BytesIO()
+                img.save(buf, format='PNG')
+                buf.seek(0)
+                return Image.open(buf)
+        except Exception:
+            pass
+        raise TypeError("Unsupported image type for resizing. Please provide a PIL.Image.Image or compatible object.")
     qr_correction_mapping = {
         'L': constants.ERROR_CORRECT_L,
         'M': constants.ERROR_CORRECT_M,
@@ -51,7 +75,7 @@ class SimpleLabel:
             text_align=TextAlign.CENTER,
             qr_size=10,
             qr_correction='L',
-            image_mode='grayscale',
+            image_fit=True,
             image=None,
             font_path='',
             font_size=70,
@@ -71,6 +95,7 @@ class SimpleLabel:
         self._font_path = font_path
         self._font_size = font_size
         self._line_spacing = line_spacing
+        self._image_fit = image_fit
 
     @property
     def label_content(self):
@@ -123,8 +148,56 @@ class SimpleLabel:
         else:
             img = None
 
+        # Initialize dimensions
+        width, height = self._width, self._height
+        margin_left, margin_right, margin_top, margin_bottom = self._label_margin
+
+        # Resize image to fit if image_fit is True
         if img is not None:
-            img_width, img_height = img.size
+            # Ensure img is a PIL image
+            pil_img = self._ensure_pil_image(img)
+
+            # Resize image to fit if image_fit is True
+            if self._image_fit:
+                # Calculate the maximum allowed dimensions
+                max_width = max(width - margin_left - margin_right, 1)
+                max_height = max(height - margin_top - margin_bottom, 1)
+
+                # Get image dimensions
+                img_width, img_height = pil_img.size
+
+                # Print the original image size
+                logger.debug(f"Maximal allowed dimensions: {max_width}x{max_height} mm")
+                logger.debug(f"Original image size: {img_width}x{img_height} px")
+
+                # Resize the image to fit within the maximum dimensions
+                scale = 1.0
+                if self._label_orientation == LabelOrientation.STANDARD:
+                    if self._label_type in (LabelType.ENDLESS_LABEL,):
+                        # Only width is considered for endless label without rotation
+                        scale = min(max_width / img_width, 1.0)
+                    else:
+                        # Both dimensions are considered for standard label
+                        scale = min(max_width / img_width, max_height / img_height, 1.0)
+                else:
+                    if self._label_type in (LabelType.ENDLESS_LABEL,):
+                        # Only height is considered for endless label without rotation
+                        scale = min(max_height / img_height, 1.0)
+                    else:
+                        # Both dimensions are considered for standard label
+                        scale = min(max_width / img_width, max_height / img_height, 1.0)
+                logger.debug(f"Scaling image by factor: {scale}")
+
+                # Resize the image
+                new_size = (int(img_width * scale), int(img_height * scale))
+                logger.debug(f"Resized image size: {new_size} px")
+                pil_img = pil_img.resize(new_size, Image.Resampling.LANCZOS)
+                # Update image dimensions
+                img_width, img_height = pil_img.size
+            else:
+                # No resizing requested
+                img_width, img_height = pil_img.size
+            img = pil_img
         else:
             img_width, img_height = (0, 0)
 
@@ -133,9 +206,7 @@ class SimpleLabel:
         else:
             textsize = (0, 0, 0, 0)
 
-        width, height = self._width, self._height
-        margin_left, margin_right, margin_top, margin_bottom = self._label_margin
-
+        # Adjust label size for endless label
         if self._label_orientation == LabelOrientation.STANDARD:
             if self._label_type in (LabelType.ENDLESS_LABEL,):
                 height = img_height + textsize[3] - textsize[1] + margin_top + margin_bottom

--- a/app/labeldesigner/printer.py
+++ b/app/labeldesigner/printer.py
@@ -1,7 +1,9 @@
-from brother_ql.backends import backend_factory, guess_backend
+import logging
+from brother_ql.backends.helpers import send
 from brother_ql import BrotherQLRaster, create_label
 from .label import LabelOrientation, LabelType, LabelContent
 
+logger = logging.getLogger(__name__)
 
 class PrinterQueue:
 
@@ -32,9 +34,6 @@ class PrinterQueue:
     @device_specifier.setter
     def device_specifier(self, value):
         self._device_specifier = value
-        selected_backend = guess_backend(self._device_specifier)
-        self._backend_class = backend_factory(
-            selected_backend)['backend_class']
 
     @property
     def label_size(self):
@@ -65,9 +64,9 @@ class PrinterQueue:
             else:
                 rotate = 'auto'
 
-            img = queue_entry['label'].generate()
+            img = queue_entry['label'].generate(rotate=False)
 
-            if queue_entry['label'].label_content == LabelContent.IMAGE_BW: 
+            if queue_entry['label'].label_content == LabelContent.IMAGE_BW:
                 dither = False
             else:
                 dither = True
@@ -81,9 +80,6 @@ class PrinterQueue:
                 cut=queue_entry['cut'],
                 rotate=rotate)
 
-        self._printQueue.clear()
-
-        be = self._backend_class(self._device_specifier)
-        be.write(qlr.data)
-        be.dispose()
-        del be
+        info = send(qlr.data, self._device_specifier)
+        logger.info('Sent %d bytes to printer %s', len(qlr.data), self._device_specifier)
+        logger.info('Printer response: %s', str(info))

--- a/app/labeldesigner/printer.py
+++ b/app/labeldesigner/printer.py
@@ -80,6 +80,8 @@ class PrinterQueue:
                 cut=queue_entry['cut'],
                 rotate=rotate)
 
+        self._printQueue.clear()
+
         info = send(qlr.data, self._device_specifier)
         logger.info('Sent %d bytes to printer %s', len(qlr.data), self._device_specifier)
         logger.info('Printer response: %s', str(info))

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -176,6 +176,12 @@ def create_label_from_request(request):
             if font_family_name is None or font_style_name is None:
                 font_family_name = current_app.config['LABEL_DEFAULT_FONT_FAMILY']
                 font_style_name = current_app.config['LABEL_DEFAULT_FONT_STYLE']
+            if font_family_name not in FONTS.fonts:
+                raise LookupError("Unknown font family: %s" % font_family_name)
+            if font_style_name not in FONTS.fonts[font_family_name]:
+                font_style_name = current_app.config['LABEL_DEFAULT_FONT_STYLE']
+            if font_style_name not in FONTS.fonts[font_family_name]:
+                raise LookupError("Unknown font style: %s" % font_style_name)
             font_path = FONTS.fonts[font_family_name][font_style_name]
         except KeyError:
             raise LookupError("Couln't find the font & style")

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -140,6 +140,7 @@ def create_label_from_request(request):
         'qrcode_correction': d.get('qrcode_correction', 'L'),
         'image_mode': d.get('image_mode', "grayscale"),
         'image_bw_threshold': int(d.get('image_bw_threshold', 70)),
+        'image_fit': int(d.get('image_fit', 1)) > 0,
         'font_size': int(d.get('font_size', 100)),
         'line_spacing': int(d.get('line_spacing', 100)),
         'font_family': d.get('font_family'),
@@ -241,6 +242,7 @@ def create_label_from_request(request):
         qr_size=context['qrcode_size'],
         qr_correction=context['qrcode_correction'],
         image=get_uploaded_image(request.files.get('image', None)),
+        image_fit=context['image_fit'],
         font_path=get_font_path(context['font_family'], context['font_style']),
         font_size=context['font_size'],
         line_spacing=context['line_spacing']

--- a/app/labeldesigner/routes.py
+++ b/app/labeldesigner/routes.py
@@ -45,7 +45,9 @@ def index():
                            default_margin_top=current_app.config['LABEL_DEFAULT_MARGIN_TOP'],
                            default_margin_bottom=current_app.config['LABEL_DEFAULT_MARGIN_BOTTOM'],
                            default_margin_left=current_app.config['LABEL_DEFAULT_MARGIN_LEFT'],
-                           default_margin_right=current_app.config['LABEL_DEFAULT_MARGIN_RIGHT']
+                           default_margin_right=current_app.config['LABEL_DEFAULT_MARGIN_RIGHT'],
+                           printer_path=current_app.config['PRINTER_PRINTER'],
+                           printer_model=current_app.config['PRINTER_MODEL']
                            )
 
 
@@ -58,8 +60,15 @@ def get_font_styles():
 
 @bp.route('/api/preview', methods=['POST', 'GET'])
 def get_preview_from_image():
+    # Set log level if provided
+    log_level = request.values.get('log_level')
+    if log_level:
+        import logging
+        level = getattr(logging, log_level.upper(), None)
+        if isinstance(level, int):
+            current_app.logger.setLevel(level)
     label = create_label_from_request(request)
-    im = label.generate()
+    im = label.generate(rotate=True)
 
     return_format = request.values.get('return_format', 'png')
 
@@ -88,6 +97,13 @@ def print_text():
     return_dict = {'success': False}
 
     try:
+        # Set log level if provided
+        log_level = request.values.get('log_level')
+        if log_level:
+            import logging
+            level = getattr(logging, log_level.upper(), None)
+            if isinstance(level, int):
+                current_app.logger.setLevel(level)
         printer = create_printer_from_request(request)
         label = create_label_from_request(request)
         print_count = int(request.values.get('print_count', 1))

--- a/app/labeldesigner/templates/labeldesigner.html
+++ b/app/labeldesigner/templates/labeldesigner.html
@@ -148,7 +148,13 @@
                                 <span class="fas fa-ruler-vertical" aria-hidden="true"> Red & Black
                             </label>
                             {% endif %}
-                               
+
+                            <div class="form-check mt-3">
+                                <input class="form-check-input" type="checkbox" value="1" onchange="preview()" id="imageFitCheckbox" checked>
+                                <label class="form-check-label" for="imageFitCheckbox">
+                                    Auto-fit image to label
+                                </label>
+                            </div>
 
                             <label for="imageBwThreshold" style="margin-top: 10px; margin-bottom: 0">Black & White threshold:</label>
                             <input id="imageBwThreshold" class="form-control" type="number" min="1" max="255" value="{{default_bw_threshold}}" onChange="preview()">

--- a/app/labeldesigner/templates/labeldesigner.html
+++ b/app/labeldesigner/templates/labeldesigner.html
@@ -166,7 +166,7 @@
                 <div class="card">
                     <div class="card-header" id="heading3">
                         <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse3" aria-expanded="true" aria-controls="collapse3">
-                            <span class="fas fa-cog" aria-hidden="true"></span> Detailed Settings
+                            <span class="fas fa-arrows-alt" aria-hidden="true"></span> Printing Margins
                         </button>
                     </div>
                     <div id="collapse3" class="collapse" aria-labelledby="heading3" data-parent="#accordion">
@@ -199,6 +199,31 @@
                                     <span class="input-group-text" id="marginRight-addon">%</span>
                                 </div>
                             </div>
+                        </div>
+                        <!-- class="card-body" -->
+                    </div>
+                </div>
+
+                <div class="card">
+                    <div class="card-header" id="heading6">
+                        <button class="btn btn-link" type="button" data-toggle="collapse" data-target="#collapse6" aria-expanded="true" aria-controls="collapse6">
+                            <span class="fas fa-print" aria-hidden="true"></span> Printer Settings
+                        </button>
+                    </div>
+                    <div id="collapse6" class="collapse" aria-labelledby="heading6" data-parent="#accordion">
+                        <div class="card-body">
+                            <label for="printerPath" style="margin-bottom: 0">Printer path:</label>
+                            <input type="text" class="form-control mb-3" id="printerPath" value="{{ printer_path }}" disabled>
+                            <label for="printerModel" style="margin-bottom: 0">Printer model:</label>
+                            <input type="text" class="form-control mb-3" id="printerModel" value="{{ printer_model }}" disabled>
+                            <label for="logLevel" style="margin-bottom: 0">Log Level:</label>
+                            <select class="form-control mb-3" id="logLevel" onChange="preview()">
+                                <option value="CRITICAL">CRITICAL</option>
+                                <option value="ERROR">ERROR</option>
+                                <option value="WARNING" selected>WARNING</option>
+                                <option value="INFO">INFO</option>
+                                <option value="DEBUG">DEBUG</option>
+                            </select>
                         </div>
                         <!-- class="card-body" -->
                     </div>

--- a/app/labeldesigner/templates/main.js
+++ b/app/labeldesigner/templates/main.js
@@ -20,6 +20,7 @@ function formData(cut_once) {
         image_mode:         $('input[name=imageMode]:checked').val(),
         image_fit:          $('#imageFitCheckbox').is(':checked') ? 1 : 0,
         print_count:       $('#printCount').val(),
+        log_level:         $('#logLevel').val(),
         {% if red_support %}
         print_color:       $('input[name=printColor]:checked').val(),
         {% endif %}

--- a/app/labeldesigner/templates/main.js
+++ b/app/labeldesigner/templates/main.js
@@ -203,5 +203,7 @@ Dropzone.options.myAwesomeDropzone = {
     }
 };
 
-updateStyles();
-preview();
+window.onload = function() {
+    updateStyles();
+    preview();
+};

--- a/app/labeldesigner/templates/main.js
+++ b/app/labeldesigner/templates/main.js
@@ -18,6 +18,7 @@ function formData(cut_once) {
         qrcode_correction: $('#qrCodeCorrection option:selected').val(),
         image_bw_threshold: $('#imageBwThreshold').val(),
         image_mode:         $('input[name=imageMode]:checked').val(),
+        image_fit:          $('#imageFitCheckbox').is(':checked') ? 1 : 0,
         print_count:       $('#printCount').val(),
         {% if red_support %}
         print_color:       $('input[name=printColor]:checked').val(),
@@ -144,9 +145,6 @@ function print(cut_once = false) {
     });
 }
 
-updateStyles();
-preview()
-
 
 var imageDropZone;
 Dropzone.options.myAwesomeDropzone = {
@@ -204,3 +202,6 @@ Dropzone.options.myAwesomeDropzone = {
         updatePreview('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNgYAAAAAMAASsJTYQAAAAASUVORK5CYII=');
     }
 };
+
+updateStyles();
+preview();

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  brother_ql_web:
+    image: davidramiro/brother-ql-web:latest # latest online version
+    # build: . # building locally from source (see git clone below))
+    container_name: brother_ql_web
+    restart: always
+    ports:
+      - "8013:8013"
+    devices:
+      - "/dev/usb/lp0:/dev/usb/lp0"
+    command: >
+      --model QL-800
+      --default-label-size 62
+      file:///dev/usb/lp0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
     restart: always
     ports:
       - "8013:8013"
-    devices:
-      - "/dev/usb/lp0:/dev/usb/lp0"
+#    devices:
+#      - "/dev/usb/lp0:/dev/usb/lp0"
     command: >
       --model QL-800
       --default-label-size 62


### PR DESCRIPTION
This PR adds a number of improvements, I will shorty summarize here:

- Add docker-compose scripts and optimize Dockerfile for better cache utilization (= faster builds during development)
- Add automatic image resizing capability
  Currently, images with wrong aspect ratios are simply cropped, making it impossible to print most images in a useful way
- Use `send()` helper instead of doing our own low-level IO with the printer
  Fixes non-printing on my QL-1100, confirmed working as expected also in an QL-800
- Fix rotation of preview image such that we always see the preview in the way the printer actually prints the label physically. This seems a much more obvious way of presenting the preview to me
- Add settings for logging level as well as (for now passive) displaying of the printer's path and model directly from the web UI
- Fix a stray error 500 during init of the page
- Add a few more standard fonts

# Auto-fit image feature

Prevents cropping

<img width="600" height="561" alt="Screenshot from 2025-08-22 1" src="https://github.com/user-attachments/assets/0916b505-b248-48d5-bdef-4cbd3ecb3daf" />

### Rotated 104 x 164 mm die-cut label (longer than wide)

<img width="1133" height="738" alt="image" src="https://github.com/user-attachments/assets/f402bc7d-d335-40f5-9a41-3c42365fdc25" />

### Non-rotated on endless paper

<img width="1953" height="1777" alt="Screenshot from 2025-08-22 3" src="https://github.com/user-attachments/assets/5b951ebd-0e17-4494-b6a5-94a90cd560be" />

### Rotated on endless paper

<img width="1133" height="738" alt="image" src="https://github.com/user-attachments/assets/0a9c09a4-9de1-428c-b8e4-275a45e016db" />

Just as an example, this is how it looks *without* the new fit-to-label feature:

<img width="353" height="432" alt="image" src="https://github.com/user-attachments/assets/ad4ba721-eef4-42e4-acf4-a0756927e091" />


### Result of the printing

The two printouts on the lest are on 62mm endless, the right is a large 104 x 164 mm die-cut shipping label (printed on QL-1100).

![signal-2025-08-23-073009_002](https://github.com/user-attachments/assets/4ccf170b-fde6-4e84-99f7-c7ba8e54f5b2)

### New setting for log level

<img width="631" height="1369" alt="Screenshot from 2025-08-22 5" src="https://github.com/user-attachments/assets/c0aed147-a368-41dc-8959-faf45fa62353" />

Source of the used demo image (not mine): https://x.com/FritzchensFritz/status/1890256507637493871/photo/1

The images were created in different stages of this PR so the menu in these screenshots may not always correspond to the latest state of this PR.